### PR TITLE
Add note about text-encoding dependency in node

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,12 @@ Unicode-aware Base64 encoding and decoding
 bower install purescript-b64
 ```
 
+In nodejs, you will need to install [text-encoding](https://www.npmjs.com/package/text-encoding) since this library depends on [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder).
+
+```
+npm install text-encoding
+```
+
 ## Documentation
 
 Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-b64).

--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ Unicode-aware Base64 encoding and decoding
 bower install purescript-b64
 ```
 
-In nodejs, you will need to install [text-encoding](https://www.npmjs.com/package/text-encoding) since this library depends on [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder).
+In nodejs, you will need to install [text-encoding](https://www.npmjs.com/package/text-encoding) since nodejs doesn't provide an implementation of [TextDecoder](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder).
 
 ```
 npm install text-encoding


### PR DESCRIPTION
Just thought it might be helpful to note the `text-encoding` dependency for those using this in node.