### PR TITLE
fix: Update stringutil package to prevent warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "purescript-prelude": "^3.0.0",
     "purescript-exceptions": "^3.0.0",
     "purescript-arraybuffer-types": "^2.0.0",
-    "purescript-stringutils": "^0.0.6",
+    "purescript-stringutils": "^0.0.7",
     "purescript-either": "^3.0.0",
     "purescript-functions": "^3.0.0",
     "purescript-encoding": "^0.0.4",

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -1,9 +1,15 @@
 module Test.Main where
 
 import Prelude
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Random (RANDOM)
 import Test.Data.Binary.Base64 as Binary
 import Test.Data.String.Base64 as String
 
+main :: Eff (console :: CONSOLE, random :: RANDOM, exception :: EXCEPTION) Unit
 main = do
   Binary.testBase64
   String.testBase64


### PR DESCRIPTION
Even though `purescript-stringutils` was set with `^`, version `0.0.6` was being installed which causes warnings. 